### PR TITLE
Update Prow to v20210310-a49501d5de

### DIFF
--- a/.prow.yaml
+++ b/.prow.yaml
@@ -5,7 +5,7 @@ presubmits:
   run_if_changed: '^(\.prow|prow/(config|plugins|cluster/jobs/.*))\.yaml$'
   spec:
     containers:
-    - image: gcr.io/k8s-prow/checkconfig:v20210305-64a6d4d83a
+    - image: gcr.io/k8s-prow/checkconfig:v20210310-a49501d5de
       command:
       - /checkconfig
       args:

--- a/prow/cluster/cherrypicker_deployment.yaml
+++ b/prow/cluster/cherrypicker_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: cherrypicker
-        image: gcr.io/k8s-prow/cherrypicker:v20210305-64a6d4d83a
+        image: gcr.io/k8s-prow/cherrypicker:v20210310-a49501d5de
         args:
         - --dry-run=false
         - --use-prow-assignments=false

--- a/prow/cluster/crier_deployment.yaml
+++ b/prow/cluster/crier_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: crier
-        image: gcr.io/k8s-prow/crier:v20210305-64a6d4d83a
+        image: gcr.io/k8s-prow/crier:v20210310-a49501d5de
         args:
         - --blob-storage-workers=1
         - --config-path=/etc/config/config.yaml

--- a/prow/cluster/deck_deployment.yaml
+++ b/prow/cluster/deck_deployment.yaml
@@ -23,7 +23,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck
-        image: gcr.io/k8s-prow/deck:v20210305-64a6d4d83a
+        image: gcr.io/k8s-prow/deck:v20210310-a49501d5de
         ports:
         - name: http
           containerPort: 8080

--- a/prow/cluster/deck_private_deployment.yaml
+++ b/prow/cluster/deck_private_deployment.yaml
@@ -19,7 +19,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: deck-private
-        image: gcr.io/k8s-prow/deck:v20210305-64a6d4d83a
+        image: gcr.io/k8s-prow/deck:v20210310-a49501d5de
         ports:
         - name: http
           containerPort: 8080

--- a/prow/cluster/ghproxy.yaml
+++ b/prow/cluster/ghproxy.yaml
@@ -34,7 +34,7 @@ spec:
     spec:
       containers:
       - name: ghproxy
-        image: gcr.io/k8s-prow/ghproxy:v20210305-64a6d4d83a
+        image: gcr.io/k8s-prow/ghproxy:v20210310-a49501d5de
         args:
         - --cache-dir=/cache
         - --cache-sizeGB=99

--- a/prow/cluster/hook_deployment.yaml
+++ b/prow/cluster/hook_deployment.yaml
@@ -25,7 +25,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: hook
-        image: gcr.io/k8s-prow/hook:v20210305-64a6d4d83a
+        image: gcr.io/k8s-prow/hook:v20210310-a49501d5de
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/horologium_deployment.yaml
+++ b/prow/cluster/horologium_deployment.yaml
@@ -18,7 +18,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: horologium
-        image: gcr.io/k8s-prow/horologium:v20210305-64a6d4d83a
+        image: gcr.io/k8s-prow/horologium:v20210310-a49501d5de
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
+++ b/prow/cluster/jobs/istio/test-infra/istio.test-infra.trusted.master.yaml
@@ -46,7 +46,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/branchprotector:v20210305-64a6d4d83a
+    - image: gcr.io/k8s-prow/branchprotector:v20210310-a49501d5de
       command:
       - /app/prow/cmd/branchprotector/app.binary
       args:
@@ -76,7 +76,7 @@ periodics:
     testgrid-create-test-group: "false"
   spec:
     containers:
-    - image: gcr.io/k8s-prow/autobump:v20210305-64a6d4d83a
+    - image: gcr.io/k8s-prow/autobump:v20210310-a49501d5de
       command:
       - /autobump.sh
       args:

--- a/prow/cluster/needs-rebase_deployment.yaml
+++ b/prow/cluster/needs-rebase_deployment.yaml
@@ -32,7 +32,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: needs-rebase
-        image: gcr.io/k8s-prow/needs-rebase:v20210305-64a6d4d83a
+        image: gcr.io/k8s-prow/needs-rebase:v20210310-a49501d5de
         args:
         - --dry-run=false
         - --github-endpoint=http://ghproxy

--- a/prow/cluster/prow-controller-manager.yaml
+++ b/prow/cluster/prow-controller-manager.yaml
@@ -20,7 +20,7 @@ spec:
       serviceAccountName: prow-controller-manager
       containers:
       - name: prow-controller-manager
-        image: gcr.io/k8s-prow/prow-controller-manager:v20210305-64a6d4d83a
+        image: gcr.io/k8s-prow/prow-controller-manager:v20210310-a49501d5de
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/sinker_deployment.yaml
+++ b/prow/cluster/sinker_deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: sinker
-        image: gcr.io/k8s-prow/sinker:v20210305-64a6d4d83a
+        image: gcr.io/k8s-prow/sinker:v20210310-a49501d5de
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/statusreconciler_deployment.yaml
+++ b/prow/cluster/statusreconciler_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       terminationGracePeriodSeconds: 180
       containers:
       - name: statusreconciler
-        image: gcr.io/k8s-prow/status-reconciler:v20210305-64a6d4d83a
+        image: gcr.io/k8s-prow/status-reconciler:v20210310-a49501d5de
         imagePullPolicy: Always
         args:
         - --config-path=/etc/config/config.yaml

--- a/prow/cluster/tide_deployment.yaml
+++ b/prow/cluster/tide_deployment.yaml
@@ -17,7 +17,7 @@ spec:
     spec:
       containers:
       - name: tide
-        image: gcr.io/k8s-prow/tide:v20210305-64a6d4d83a
+        image: gcr.io/k8s-prow/tide:v20210310-a49501d5de
         args:
         - --config-path=/etc/config/config.yaml
         - --dry-run=false

--- a/prow/cluster/tot_deployment.yaml
+++ b/prow/cluster/tot_deployment.yaml
@@ -49,7 +49,7 @@ spec:
       terminationGracePeriodSeconds: 30
       containers:
       - name: tot
-        image: gcr.io/k8s-prow/tot:v20210305-64a6d4d83a
+        image: gcr.io/k8s-prow/tot:v20210310-a49501d5de
         args:
         - -storage=/store/tot.json
         - -fallback

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -399,6 +399,9 @@ tide:
     istio-private: squash
   target_url: https://prow.istio.io/tide
   blocker_label: tide/merge-blocker
+  squash_label: tide/merge-method-squash
+  rebase_label: tide/merge-method-rebase
+  merge_label: tide/merge-method-merge
   context_options:
     from-branch-protection: true
     skip-unknown-contexts: true

--- a/prow/config.yaml
+++ b/prow/config.yaml
@@ -11,10 +11,10 @@ plank:
       timeout: 2h
       grace_period: 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210305-64a6d4d83a"
-        initupload: "gcr.io/k8s-prow/initupload:v20210305-64a6d4d83a"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210305-64a6d4d83a"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20210305-64a6d4d83a"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210310-a49501d5de"
+        initupload: "gcr.io/k8s-prow/initupload:v20210310-a49501d5de"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210310-a49501d5de"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20210310-a49501d5de"
       gcs_configuration:
         bucket: "istio-prow"
         path_strategy: "explicit"
@@ -23,10 +23,10 @@ plank:
       timeout: 2h
       grace_period: 15s
       utility_images:
-        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210305-64a6d4d83a"
-        initupload: "gcr.io/k8s-prow/initupload:v20210305-64a6d4d83a"
-        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210305-64a6d4d83a"
-        sidecar: "gcr.io/k8s-prow/sidecar:v20210305-64a6d4d83a"
+        clonerefs: "gcr.io/k8s-prow/clonerefs:v20210310-a49501d5de"
+        initupload: "gcr.io/k8s-prow/initupload:v20210310-a49501d5de"
+        entrypoint: "gcr.io/k8s-prow/entrypoint:v20210310-a49501d5de"
+        sidecar: "gcr.io/k8s-prow/sidecar:v20210310-a49501d5de"
       gcs_configuration:
         bucket: "istio-private-build"
         path_strategy: "explicit"

--- a/prow/istio-autobump-config.yaml
+++ b/prow/istio-autobump-config.yaml
@@ -1,0 +1,23 @@
+---
+gitHubLogin: "istio-testing"
+gitHubToken: "/etc/github-token/oauth"
+onCallAddress: "https://storage.googleapis.com/kubernetes-jenkins/oncall.json"
+skipPullRequest: false
+gitHubOrg: "istio"
+gitHubRepo: "test-infra"
+remoteName: "test-infra"
+headBranchName: "autobump-prow"
+upstreamURLBase: "https://raw.githubusercontent.com/kubernetes/test-infra/master"
+includedConfigPaths:
+  - prow/cluster
+targetVersion: "upstream"
+extraFiles:
+  - ".prow.yaml"
+  - "prow/config.yaml"
+prefixes: 
+  - name: "Prow"
+    prefix: "gcr.io/k8s-prow/"
+    repo: "https://github.com/kubernetes/test-infra"
+    refConfigFile: "config/prow/cluster/deck_deployment.yaml"
+    summarise: false
+    consistentImages: true


### PR DESCRIPTION
Multiple distinct Prow changes:

Commits | Dates | Images
--- | --- | ---
https://github.com/kubernetes/test-infra/compare/64a6d4d83a...a49501d5de | 2021&#x2011;03&#x2011;05&nbsp;&#x2192;&nbsp;2021&#x2011;03&#x2011;10 | autobump, branchprotector, checkconfig, cherrypicker, clonerefs, crier, deck, entrypoint, ghproxy, hook, horologium, initupload, needs-rebase, prow-controller-manager, sidecar, sinker, status-reconciler, tide, tot



